### PR TITLE
Fixes #1: Make agent name configurable from env variable

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,14 @@
 import agent
+import os
 from agent import Agent
+from dotenv import load_dotenv
 
-agent = Agent("myAgent")
+# Load default environment variables (.env)
+load_dotenv()
+
+AGENT_NAME = os.getenv("AGENT_NAME") or "my-agent"
+
+agent = Agent(AGENT_NAME)
 
 # Creates Pinecone Index
 agent.createIndex()


### PR DESCRIPTION
The agent name that was hardcoded had to be changed to avoid this error response I was getting from pinecone:

```
HTTP response body: Index name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character
```

Whlist changing it I also made it optionally configurable via an env variable