### PR TITLE
Provide option to easily run system in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+ENV PIP_NO_CACHE_DIR=true
+WORKDIR /tmp
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install -r requirements.txt
+
+WORKDIR /app
+COPY . /app
+ENTRYPOINT ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Here is what happens everytime the AI is queried by the user:
 3. Set your OpenAI and Pinecone API info in the OPENAI_API_KEY, PINECONE_API_KEY, and PINECONE_API_ENV variables.
 4. Run `python main.py` and talk to the AI in the terminal
 
+## Running in a docker container
+You can run the system isolated in a container using docker-compose:
+```
+docker-compose run teenage-agi
+```
+
 ## Experiments
 Currently, using GPT-4, I found that it can remember its name and other characteristics. It also carries on the conversation quite well without a context window (although I might add it soon). I will update this section as I keep playing with it.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+
+services:
+  teenage-agi:
+    build: ./
+    volumes:
+      - "./:/app"
+    profiles: ["exclude-from-up"] # Use `docker-compose run teenage-agi` to get an attached container


### PR DESCRIPTION
You can now run system isolated in a container with one command:

```
docker-compose run teenage-agi
```

Via docker-compose it's now easier to add supporting containers if needed in future (eg. redis)